### PR TITLE
Respect adapter-level options in adapter.receive()

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,8 +52,8 @@ module.exports = function DiskStore(options) {
     }
   };
 
-  adapter.receive = function(options) {
-    return r_buildDiskReceiverStream(options, adapter);
+  adapter.receive = function(opts) {
+    return r_buildDiskReceiverStream(_.defaults(opts, options), adapter);
   };
 
   return adapter;


### PR DESCRIPTION
According to [Skipper's docs](https://github.com/balderdashy/skipper#specifying-options), the adapter factory method may take an `options` object that will become the defaults for all subsequent operations on that adapter, unless overriden in calls to `adapter.receive()` or `file.upload()`.

This behaviour was not respected - the adapter-level defaults were not applied. This PR remedies that.