### PR TITLE
Fix links and remove extra spacing from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-# [<img title="skipper-disk - Local disk adapter for Skipper" src="http://i.imgur.com/P6gptnI.png" width="200px" alt="skipper emblem - face of a ship's captain"/>](https://github.com/balderdashy/skipper-disk) Disk Blob Adapter
+# [<img title="skipper-disk - Local disk adapter for Skipper" src="http://i.imgur.com/P6gptnI.png" width="150px" alt="skipper emblem - face of a ship's captain"/>](https://github.com/balderdashy/skipper-disk) Disk Blob Adapter
 
 [![NPM version](https://badge.fury.io/js/skipper-disk.png)](http://badge.fury.io/js/skipper-disk) &nbsp; &nbsp;
 [![Build Status](https://travis-ci.org/balderdashy/skipper-disk.svg?branch=master)](https://travis-ci.org/balderdashy/skipper-disk)
 
-Local filesystem adapter for receiving [upstreams](https://github.com/balderdashy/skipper#what-are-upstreams). Particularly useful for streaming multipart file uploads from the [Skipper](github.com/balderdashy/skipper) body parser.
-
+Local filesystem adapter for receiving [upstreams](https://github.com/balderdashy/skipper#what-are-upstreams). Particularly useful for streaming multipart file uploads from the [Skipper](https://github.com/balderdashy/skipper) body parser.
 
 ## Installation
 
@@ -15,8 +14,6 @@ $ npm install skipper-disk --save
 This module is part of the default configuration in [Sails](https://sailsjs.com).
 
 > If you're using this module outside of Sails (e.g. Express or a vanilla Node.js server), make sure you have skipper itself [installed as your body parser](https://sailsjs.com/documentation/concepts/middleware?q=adding-or-overriding-http-middleware).
-
-
 
 ## Usage
 
@@ -37,8 +34,7 @@ req.file('avatar')
 });
 ```
 
-For more detailed usage information and a full list of available options, see the Skipper repo, especially the section on "[https://github.com/balderdashy/skipper#uploading-files-to-disk](Uploading to Local Disk)".
-
+For more detailed usage information and a full list of available options, see the Skipper repo, especially the section on ["Uploading to Local Disk"](https://github.com/balderdashy/skipper#uploading-files-to-disk).
 
 ## Contribute
 
@@ -50,9 +46,6 @@ To run the tests:
 $ npm test
 ```
 
-
-
-
 ## License
 
 **[MIT](./LICENSE)**
@@ -62,7 +55,6 @@ $ npm test
 See `LICENSE.md`.
 
 This module is part of the [Sails framework](https://sailsjs.com), and is free and open-source under the [MIT License](https://sailsjs.com/license).
-
 
 ![image_squidhome@2x.png](http://i.imgur.com/RIvu9.png)
 


### PR DESCRIPTION
- Fixed the `Uploading to local disk` link
- Add `https` to skipper link
- Remove extra spacing in the README file